### PR TITLE
Light graphs integration

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 FactCheck
 Compat
 Docile
+LightGraphs

--- a/src/GraphMatrices.jl
+++ b/src/GraphMatrices.jl
@@ -55,15 +55,16 @@ abstract Adjacency{T} <: GraphMatrix{T}
 abstract Laplacian{T} <: GraphMatrix
 
 @doc "Combinatorial Adjacency matrix is the standard adjacency matrix from math" ->
-type CombinatorialAdjacency{T} <: Adjacency{T}
-	A::SparseMatrix{T}
-	D::Vector{T}
+type CombinatorialAdjacency{T,S,V} <: Adjacency{T}
+	A::S
+	D::V
 end
 
 function CombinatorialAdjacency{T}(A::SparseMatrix{T})
 	D = vec(sum(A,1))
-	return CombinatorialAdjacency(A,D)
+	return CombinatorialAdjacency{T,SparseMatrix{T},typeof(D)}(A,D)
 end
+
 
 @doc "Normalized Adjacency matrix is \$\\hat{A} = D^{-1/2} A D^{-1/2}\$.
 If A is symmetric, then the normalized adjacency is also symmetric

--- a/test/lightgraphs.jl
+++ b/test/lightgraphs.jl
@@ -1,11 +1,15 @@
+module TestLightGraphs
 using LightGraphs
 using GraphMatrices
 using FactCheck
+include("types.jl")
+
+using TestGraphMatrices
 
 import GraphMatrices.CombinatorialAdjacency
 
 function CombinatorialAdjacency(A)
-    D = indegree(A, vertices(A))
+    D = float(indegree(A, vertices(A)))
     return CombinatorialAdjacency{Float64, typeof(A), typeof(D)}(A,D)
 end
 
@@ -14,4 +18,35 @@ facts("constructors") do
     Ag = CombinatorialAdjacency(g)
     Am = CombinatorialAdjacency(adjacency_matrix(g))
     @fact Ag => truthy
+end
+
+facts("constructors") do
+	n = 10
+    mat = PathGraph(10)
+	context("Adjacency") do
+        test_adjacency(mat)
+    end
+
+	context("Laplacian") do
+        test_laplacian(mat)
+    end
+
+	context("Accessors") do
+        test_accessors(mat, n)
+    end
+end
+
+
+facts("arithmetic") do
+	n = 10
+    mat = PathGraph(10)
+    test_arithmetic(mat, n)
+end
+
+facts("other tests") do
+    n = 10
+    mat = PathGraph(10)
+    test_other(mat, n)
+end
+
 end

--- a/test/lightgraphs.jl
+++ b/test/lightgraphs.jl
@@ -1,0 +1,17 @@
+using LightGraphs
+using GraphMatrices
+using FactCheck
+
+import GraphMatrices.CombinatorialAdjacency
+
+function CombinatorialAdjacency(A)
+    D = indegree(A, vertices(A))
+    return CombinatorialAdjacency{Float64, typeof(A), typeof(D)}(A,D)
+end
+
+facts("constructors") do
+    g = PathGraph(10)
+    Ag = CombinatorialAdjacency(g)
+    Am = CombinatorialAdjacency(adjacency_matrix(g))
+    @fact Ag => truthy
+end

--- a/test/lightgraphs.jl
+++ b/test/lightgraphs.jl
@@ -6,6 +6,13 @@ include("types.jl")
 
 using TestGraphMatrices
 
+function symmetrize(g::Graph, s::Symbol)
+    return g
+end
+function symmetrize(g::DiGraph, s::Symbol)
+    return Graph(g)
+end
+
 import GraphMatrices.CombinatorialAdjacency
 
 function CombinatorialAdjacency(A)
@@ -40,6 +47,11 @@ end
 facts("arithmetic") do
 	n = 10
     mat = PathGraph(10)
+    @fact eltype(mat) => Float64
+    @fact zero(eltype(mat)) => 0.0
+    adjmat = CombinatorialAdjacency(mat)
+    @fact eltype(adjmat) => Float64
+    @fact zero(eltype(adjmat)) => 0.0
     test_arithmetic(mat, n)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using FactCheck
 
 include("types.jl")
 include("randwalk.jl")
+include("lightgraphs.jl")


### PR DESCRIPTION
This PR addresses #1.
This builds when LightGraphs is installed. We need to find a home for this code:

``` julia
function CombinatorialAdjacency(A)
    D = indegree(A, vertices(A))
    return CombinatorialAdjacency{Float64, typeof(A), typeof(D)}(A,D)
end
```

and the tests.
